### PR TITLE
Update settings.py to cover 24h/day (19:00-20:00 was undefined)

### DIFF
--- a/reia/config/settings.py
+++ b/reia/config/settings.py
@@ -92,10 +92,10 @@ class REIASettings(Settings):
         }
 
     periods: dict[str, list] = Field(default={
-        'night': [(time(20, 0), time(23, 59, 59, 59)),
+        'night': [(time(19, 30), time(23, 59, 59, 999999)),
                   (time(0, 0), time(7, 0))],
         'transit': [(time(7, 0), time(9, 0)),
-                    (time(17, 0), time(19, 0))],
+                    (time(17, 0), time(19, 30))],
         'day': [(time(9, 0), time(17, 0))]
     })
 


### PR DESCRIPTION
Fix:
The time between 19:00 and 20:00 did not match any of the exposure profiles "day", "transition" and "night", making loss calculations in this interval to fail. This is fixed (transition time ends at 19:00, night scheme afterwards)

Further suggestions:
- i would expect morning transition to be rather between 6:00 and 8:00 (local time) than 7:00 to 9:00. Hardly any time-controlled jobs start after 8:00.
- in my understanding, these times are meant to describe the behavior in local time. However, they are interpreted ass UTC when matching to the earthquake time (not exaclty defined, but in scientific context also given in UTC. So they should probably be shifted by one hour, or the time zone indicated
- The behaviour of people changes (with reference to UTC) due to daylight saving time - this is not considered yet (but can hopefully be considered withouth changing settings.py twice a year...)